### PR TITLE
SFT-2125: Use nonnull attribute when possible.

### DIFF
--- a/ffi/cbindgen.toml
+++ b/ffi/cbindgen.toml
@@ -18,6 +18,13 @@ autogen_warning = """
 include_version = false
 usize_is_size_t = true
 cpp_compat = true
+after_includes = """
+
+#if defined(__clang__)
+#define FOUNDATION_NONNULL __attribute__((nonnull))
+#else
+#define FOUNDATION_NONNULL
+#endif"""
 line_length = 80
 documentation_style = "doxy"
 style = "type"
@@ -25,3 +32,6 @@ style = "type"
 [export]
 prefix = "FOUNDATION_"
 item_types = ["constants", "functions"]
+
+[ptr]
+non_null_attribute = "FOUNDATION_NONNULL"

--- a/ffi/include/foundation.h
+++ b/ffi/include/foundation.h
@@ -18,6 +18,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#if defined(__clang__)
+#define FOUNDATION_NONNULL __attribute__((nonnull))
+#else
+#define FOUNDATION_NONNULL
+#endif
+
 /**
  * Encoded length of a `npub` in bytes.
  */
@@ -35,14 +41,14 @@ extern "C" {
 /**
  * Encode a public key to a Nostr `npub`.
  */
-void foundation_encode_npub(const uint8_t (*public_key)[32],
-                            uint8_t (*output)[FOUNDATION_NPUB_LEN]);
+void foundation_encode_npub(const uint8_t (*FOUNDATION_NONNULL public_key)[32],
+                            uint8_t (*FOUNDATION_NONNULL output)[FOUNDATION_NPUB_LEN]);
 
 /**
  * Encode a secret key to a Nostr `nsec`.
  */
-void foundation_encode_nsec(const uint8_t (*secret_key)[32],
-                            uint8_t (*output)[FOUNDATION_NSEC_LEN]);
+void foundation_encode_nsec(const uint8_t (*FOUNDATION_NONNULL secret_key)[32],
+                            uint8_t (*FOUNDATION_NONNULL output)[FOUNDATION_NSEC_LEN]);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
When compiling with clang it should check for NULL types passed to the function, also allows some optimizations by the compiler.