### PR TITLE
SFT-2570: Fix broken version of proc-macro2.

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -41,4 +41,13 @@ jobs:
         with:
           toolchain: nightly
       - run: rustup override set nightly
+      # proc-macro2 is broken in recent nightly versions of Rust as it
+      # automagically enables some nightly features that don't exist on recent
+      # nightly compilers.
+      #
+      # Once our dependencies update the proc-macro2 version used to be higher
+      # than the one pinned here we can remove this hack.
+      #
+      # This is not needed for stable versions.
+      - run: cargo update proc-macro2 --precise 1.0.66 -Z minimal-versions
       - run: cargo check -Z minimal-versions


### PR DESCRIPTION
* .github/workflows/dependencies.yaml (are-versions-really-minimal):

  Pin the version of proc-macro2 before checking for minimal dependencies.