### PR TITLE
SFT-3538: Update minicbor.

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -29,15 +29,6 @@ jobs:
         with:
           toolchain: nightly
       - run: rustup override set nightly
-      # proc-macro2 is broken in recent nightly versions of Rust as it
-      # automagically enables some nightly features that don't exist on recent
-      # nightly compilers.
-      #
-      # Once our dependencies update the proc-macro2 version used to be higher
-      # than the one pinned here we can remove this hack.
-      #
-      # This is not needed for stable versions.
-      - run: cargo update -p proc-macro2 --precise 1.0.66 -Z minimal-versions
       # hex-conservative uses wrong minimal versions.
       - run: cargo update -p arrayvec --precise 0.7.4 -Z minimal-versions
       - run: cargo check -Z minimal-versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ heapless = { version = "0.8", default-features = false }
 hex = { version = "0.4.2", default-features = false }
 itertools = { version = "0.10", default-features = false }
 libfuzzer-sys = "0.4"
-minicbor = { version = "0.20", features = ["derive"] }
+minicbor = { version = "0.24", features = ["derive"] }
 nom = { version = "7", default-features = false }
 phf = { version = "0.11", features = ["macros"], default-features = false }
 rand_xoshiro = "0.6"

--- a/urtypes/src/cbor/timestamp.rs
+++ b/urtypes/src/cbor/timestamp.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use minicbor::{
-    data::{Int, Tag, Type},
+    data::{IanaTag, Int, Tag, Type},
     decode::Error,
     encode::Write,
     Decode, Decoder, Encode, Encoder,
@@ -22,7 +22,7 @@ pub enum Timestamp {
 #[rustfmt::skip]
 impl<'b, C> Decode<'b, C> for Timestamp {
     fn decode(d: &mut Decoder<'b>, _ctx: &mut C) -> Result<Self, Error> {
-        if d.tag()? != Tag::Timestamp {
+        if d.tag()? != Tag::from(IanaTag::Timestamp) {
             return Err(Error::message("invalid timestamp tag"));
         }
 
@@ -45,7 +45,7 @@ impl<C> Encode<C> for Timestamp {
         e: &mut Encoder<W>,
         _ctx: &mut C,
     ) -> Result<(), minicbor::encode::Error<W::Error>> {
-        e.tag(Tag::Timestamp)?;
+        e.tag(IanaTag::Timestamp)?;
 
         match self {
             Timestamp::Int(x) => e.int(*x)?,

--- a/urtypes/src/cbor/uuid.rs
+++ b/urtypes/src/cbor/uuid.rs
@@ -23,7 +23,7 @@ use minicbor::{data::Tag, decode::Error, encode::Write, Decoder, Encoder};
 use uuid::Uuid;
 
 /// Tag representing of [`Uuid`].
-pub const TAG: Tag = Tag::Unassigned(37);
+pub const TAG: Tag = Tag::new(37);
 
 /// Encode an [`Uuid`].
 pub fn encode<C, W: Write>(

--- a/urtypes/src/passport.rs
+++ b/urtypes/src/passport.rs
@@ -27,7 +27,7 @@ pub enum Model {
 
 impl Model {
     /// Tag for embedding [`Model`] in other types.
-    pub const TAG: Tag = Tag::Unassigned(721);
+    pub const TAG: Tag = Tag::new(721);
 }
 
 impl<'b, C> Decode<'b, C> for Model {

--- a/urtypes/src/registry/crypto_address.rs
+++ b/urtypes/src/registry/crypto_address.rs
@@ -25,7 +25,7 @@ pub struct CryptoAddress<'a> {
 impl<'a> CryptoAddress<'a> {
     /// The CBOR tag used when [`CryptoAddress`] is embedded in other CBOR
     /// types.
-    pub const TAG: Tag = Tag::Unassigned(307);
+    pub const TAG: Tag = Tag::new(307);
 }
 
 #[cfg(feature = "bitcoin")]

--- a/urtypes/src/registry/crypto_coininfo.rs
+++ b/urtypes/src/registry/crypto_coininfo.rs
@@ -21,7 +21,7 @@ pub struct CryptoCoinInfo {
 
 impl CryptoCoinInfo {
     /// Tag for embedding [`CryptoCoinInfo`] in other types.
-    pub const TAG: Tag = Tag::Unassigned(305);
+    pub const TAG: Tag = Tag::new(305);
 
     /// Universal value for unique network.
     pub const NETWORK_MAINNET: u64 = 0;

--- a/urtypes/src/registry/crypto_eckey.rs
+++ b/urtypes/src/registry/crypto_eckey.rs
@@ -22,7 +22,7 @@ pub struct CryptoECKey<'a> {
 
 impl<'a> CryptoECKey<'a> {
     /// The CBOR tag used when [`CryptoECKey`] is embedded in other CBOR types.
-    pub const TAG: Tag = Tag::Unassigned(306);
+    pub const TAG: Tag = Tag::new(306);
 
     /// `secp256k1` curve type.
     pub const SECP256K1: u64 = 0;

--- a/urtypes/src/registry/crypto_hdkey.rs
+++ b/urtypes/src/registry/crypto_hdkey.rs
@@ -22,7 +22,7 @@ pub enum CryptoHDKey<'a> {
 
 impl<'a> CryptoHDKey<'a> {
     /// The CBOR tag used when [`CryptoHDKey`] is embedded in other CBOR types.
-    pub const TAG: Tag = Tag::Unassigned(303);
+    pub const TAG: Tag = Tag::new(303);
 }
 
 #[cfg(feature = "bitcoin")]
@@ -254,20 +254,23 @@ impl<'b, C> Decode<'b, C> for DerivedKey<'b> {
                 }
             }
 
+            const TAGGED_COININFO: Tag = Tag::new(305);
+            const TAGGED_KEYPATH: Tag = Tag::new(304);
+
             match d.u32()? {
                 2 => is_private = d.bool()?,
                 3 => key_data = Some(DecodeBytes::decode_bytes(d, ctx)?),
                 4 => chain_code = Some(DecodeBytes::decode_bytes(d, ctx)?),
                 5 => match d.tag()? {
-                    Tag::Unassigned(305) => use_info = Some(CryptoCoinInfo::decode(d, ctx)?),
+                    TAGGED_COININFO => use_info = Some(CryptoCoinInfo::decode(d, ctx)?),
                     _ => return Err(Error::message("invalid tag for crypto-coininfo")),
                 },
                 6 => match d.tag()? {
-                    Tag::Unassigned(304) => origin = Some(CryptoKeypath::decode(d, ctx)?),
+                    TAGGED_KEYPATH => origin = Some(CryptoKeypath::decode(d, ctx)?),
                     _ => return Err(Error::message("invalid tag for crypto-keypath")),
                 },
                 7 => match d.tag()? {
-                    Tag::Unassigned(304) => children = Some(CryptoKeypath::decode(d, ctx)?),
+                    TAGGED_KEYPATH => children = Some(CryptoKeypath::decode(d, ctx)?),
                     _ => return Err(Error::message("invalid tag for crypto-keypath")),
                 },
                 8 => {
@@ -325,17 +328,17 @@ impl<'a, C> Encode<C> for DerivedKey<'a> {
         }
 
         if let Some(ref use_info) = self.use_info {
-            e.u8(5)?.tag(Tag::Unassigned(305))?;
+            e.u8(5)?.tag(Tag::new(305))?;
             use_info.encode(e, ctx)?;
         }
 
         if let Some(ref origin) = self.origin {
-            e.u8(6)?.tag(Tag::Unassigned(304))?;
+            e.u8(6)?.tag(Tag::new(304))?;
             origin.encode(e, ctx)?;
         }
 
         if let Some(ref children) = self.children {
-            e.u8(7)?.tag(Tag::Unassigned(304))?;
+            e.u8(7)?.tag(Tag::new(304))?;
             children.encode(e, ctx)?;
         }
 

--- a/urtypes/src/registry/crypto_output.rs
+++ b/urtypes/src/registry/crypto_output.rs
@@ -55,17 +55,17 @@ pub enum Terminal<'a, 'b> {
 }
 
 impl<'a, 'b> Terminal<'a, 'b> {
-    const TAG_SCRIPT_HASH: Tag = Tag::Unassigned(400);
-    const TAG_WITNESS_SCRIPT_HASH: Tag = Tag::Unassigned(401);
-    const TAG_PUBLIC_KEY: Tag = Tag::Unassigned(402);
-    const TAG_PUBLIC_KEY_HASH: Tag = Tag::Unassigned(403);
-    const TAG_WITNESS_PUBLIC_KEY_HASH: Tag = Tag::Unassigned(404);
-    const TAG_COMBO: Tag = Tag::Unassigned(405);
-    const TAG_MULTISIG: Tag = Tag::Unassigned(406);
-    const TAG_SORTED_MULTISIG: Tag = Tag::Unassigned(407);
-    const TAG_RAW_SCRIPT: Tag = Tag::Unassigned(408);
-    const TAG_TAPROOT: Tag = Tag::Unassigned(409);
-    const TAG_COSIGNER: Tag = Tag::Unassigned(410);
+    const TAG_SCRIPT_HASH: Tag = Tag::new(400);
+    const TAG_WITNESS_SCRIPT_HASH: Tag = Tag::new(401);
+    const TAG_PUBLIC_KEY: Tag = Tag::new(402);
+    const TAG_PUBLIC_KEY_HASH: Tag = Tag::new(403);
+    const TAG_WITNESS_PUBLIC_KEY_HASH: Tag = Tag::new(404);
+    const TAG_COMBO: Tag = Tag::new(405);
+    const TAG_MULTISIG: Tag = Tag::new(406);
+    const TAG_SORTED_MULTISIG: Tag = Tag::new(407);
+    const TAG_RAW_SCRIPT: Tag = Tag::new(408);
+    const TAG_TAPROOT: Tag = Tag::new(409);
+    const TAG_COSIGNER: Tag = Tag::new(410);
 }
 
 fn oom() -> Error {

--- a/urtypes/src/registry/crypto_seed.rs
+++ b/urtypes/src/registry/crypto_seed.rs
@@ -31,7 +31,7 @@ pub mod digest {
     use minicbor::{Decoder, Encoder};
 
     /// Tag representing a `crypto-seed-digest`.
-    pub const TAG: Tag = Tag::Unassigned(600);
+    pub const TAG: Tag = Tag::new(600);
 
     /// Encode a `crypto-seed-digest`.
     #[doc(alias("crypto-seed-digest"))]

--- a/urtypes/src/registry/passport.rs
+++ b/urtypes/src/registry/passport.rs
@@ -54,11 +54,11 @@ use minicbor::{
 use uuid::Uuid;
 
 /// Passport model request tag.
-const PASSPORT_MODEL_REQUEST_TAG: Tag = Tag::Unassigned(720);
+const PASSPORT_MODEL_REQUEST_TAG: Tag = Tag::new(720);
 /// Passport firmware version request tag.
-const PASSPORT_FIRMWARE_VERSION_REQUEST_TAG: Tag = Tag::Unassigned(770);
+const PASSPORT_FIRMWARE_VERSION_REQUEST_TAG: Tag = Tag::new(770);
 /// Passport firmware version response tag.
-const PASSPORT_FIRMWARE_VERSION_RESPONSE_TAG: Tag = Tag::Unassigned(771);
+const PASSPORT_FIRMWARE_VERSION_RESPONSE_TAG: Tag = Tag::new(771);
 
 /// Passport custom `crypto-request`.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]

--- a/urtypes/src/supply_chain_validation.rs
+++ b/urtypes/src/supply_chain_validation.rs
@@ -45,7 +45,7 @@ pub struct Challenge {
 
 impl Challenge {
     /// Tag for embedding [`Challenge`] in other types.
-    pub const TAG: Tag = Tag::Unassigned(710);
+    pub const TAG: Tag = Tag::new(710);
 }
 
 impl<'b, C> Decode<'b, C> for Challenge {
@@ -134,5 +134,5 @@ pub struct Solution<'a> {
 
 impl<'a> Solution<'a> {
     /// Tag for embedding [`Solution`] in other types.
-    pub const TAG: Tag = Tag::Unassigned(711);
+    pub const TAG: Tag = Tag::new(711);
 }


### PR DESCRIPTION
* Cargo.toml (workspace.dependencies) \<minicbor\>: Update to 0.24.
* src/cbor/timestamp.rs: Fix breaking changes.
* src/cbor/uuid.rs: Ditto.
* src/passport.rs: Ditto.
* src/registry/crypto_address.rs: Ditto.
* src/registry/crypto_coininfo.rs: Ditto.
* src/registry/crypto_eckey.rs: Ditto.
* src/registry/crypto_hdkey.rs: Ditto.
* src/registry/crypto_output.rs: Ditto.
* src/registry/crypto_seed.rs: Ditto.
* src/registry/passport.rs: Ditto.
* src/supply_chain_validation.rs: Ditto.