### PR TITLE
[AI] urtypes: add crypto-output UR decode helper (SFT-6915)

### DIFF
--- a/urtypes/src/value.rs
+++ b/urtypes/src/value.rs
@@ -30,7 +30,7 @@ use core::fmt::{Display, Formatter};
 
 use minicbor::{bytes::ByteSlice, encode::Write, Encode, Encoder};
 
-use crate::registry::{HDKeyRef, PassportRequest, PassportResponse};
+use crate::registry::{HDKeyRef, PassportRequest, PassportResponse, Terminal, TerminalContext};
 
 #[derive(Debug, PartialEq)]
 pub enum Value<'a> {
@@ -67,6 +67,15 @@ impl<'a> Value<'a> {
         Ok(value)
     }
 
+    /// Whether `ur_type` is a known output-descriptor UR type.
+    ///
+    /// Accepts the historical `crypto-output` spelling (BCR-2020-010, still
+    /// emitted by e.g. Sparrow) as well as the newer `output-descriptor` and
+    /// short `output` aliases.
+    pub fn is_output_descriptor(ur_type: &str) -> bool {
+        matches!(ur_type, "output" | "output-descriptor" | "crypto-output")
+    }
+
     /// Return the type of this value as a string.
     ///
     /// # Notes
@@ -85,6 +94,28 @@ impl<'a> Value<'a> {
             Value::PassportResponse(_) => "crypto-response",
         }
     }
+}
+
+/// Decode a `crypto-output` / `output-descriptor` UR payload into a [`Terminal`].
+///
+/// [`Terminal`] is a recursive data structure, so its sub-nodes are allocated
+/// into the caller-provided [`TerminalContext`] arena. `N` must be large
+/// enough to hold every nested `Terminal` node in the descriptor (e.g. a
+/// `wsh(sortedmulti(...))` needs at least 2 slots).
+///
+/// Dispatches on the UR type string so callers can route from a generic
+/// "got a UR" entry point without re-implementing the aliases. See
+/// [`Value::is_output_descriptor`] for the accepted spellings.
+pub fn decode_output_descriptor<'a, 'b, const N: usize>(
+    ur_type: &str,
+    payload: &'b [u8],
+    arena: &'a TerminalContext<'a, 'b, N>,
+) -> Result<Terminal<'a, 'b>, Error> {
+    if !Value::is_output_descriptor(ur_type) {
+        return Err(Error::UnsupportedResource);
+    }
+    let mut ctx: &'a TerminalContext<'a, 'b, N> = arena;
+    minicbor::decode_with::<_, Terminal>(payload, &mut ctx).map_err(Into::into)
 }
 
 impl<'a, C> Encode<C> for Value<'a> {
@@ -140,6 +171,80 @@ impl From<minicbor::decode::Error> for Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::registry::{ECKey, Key, Multikey, Terminal, TerminalContext};
+    use foundation_arena::boxed::Box as ArenaBox;
+
+    #[test]
+    fn test_is_output_descriptor() {
+        assert!(Value::is_output_descriptor("output"));
+        assert!(Value::is_output_descriptor("output-descriptor"));
+        assert!(Value::is_output_descriptor("crypto-output"));
+        assert!(!Value::is_output_descriptor("hdkey"));
+        assert!(!Value::is_output_descriptor("crypto-hdkey"));
+        assert!(!Value::is_output_descriptor(""));
+    }
+
+    fn sample_wsh_sortedmulti_cbor() -> alloc::vec::Vec<u8> {
+        // wsh(sorted_multi(2 of 2)) — the flavor Sparrow emits for BIP48
+        // P2WSH multisigs. Same keys as `output_descriptor::test_example_3`.
+        let a: TerminalContext<8> = TerminalContext::new();
+        let key1 = Key::ECKey(ECKey {
+            curve: ECKey::SECP256K1,
+            is_private: false,
+            data: &[
+                0x02, 0x2f, 0x01, 0xe5, 0xe1, 0x5c, 0xca, 0x35, 0x1d, 0xaf, 0xf3, 0x84, 0x3f, 0xb7,
+                0x0f, 0x3c, 0x2f, 0x0a, 0x1b, 0xdd, 0x05, 0xe5, 0xaf, 0x88, 0x8a, 0x67, 0x78, 0x4e,
+                0xf3, 0xe1, 0x0a, 0x2a, 0x01,
+            ],
+        });
+        let key2 = Key::ECKey(ECKey {
+            curve: ECKey::SECP256K1,
+            is_private: false,
+            data: &[
+                0x03, 0xac, 0xd4, 0x84, 0xe2, 0xf0, 0xc7, 0xf6, 0x53, 0x09, 0xad, 0x17, 0x8a, 0x9f,
+                0x55, 0x9a, 0xbd, 0xe0, 0x97, 0x96, 0x97, 0x4c, 0x57, 0xe7, 0x14, 0xc3, 0x5f, 0x11,
+                0x0d, 0xfc, 0x27, 0xcc, 0xbe,
+            ],
+        });
+        let keys: &[Key] = &[key1, key2];
+        let sortedmulti = ArenaBox::new_in(
+            Terminal::SortedMultisig(Multikey {
+                threshold: 2,
+                keys: keys.into(),
+            }),
+            &a,
+        )
+        .unwrap();
+        let descriptor = Terminal::WitnessScriptHash(sortedmulti);
+        minicbor::to_vec(&descriptor).unwrap()
+    }
+
+    #[test]
+    fn test_decode_output_descriptor_crypto_output_alias() {
+        let cbor = sample_wsh_sortedmulti_cbor();
+        let arena: TerminalContext<8> = TerminalContext::new();
+        let decoded = decode_output_descriptor("crypto-output", &cbor, &arena).unwrap();
+        assert!(matches!(decoded, Terminal::WitnessScriptHash(_)));
+    }
+
+    #[test]
+    fn test_decode_output_descriptor_new_alias() {
+        let cbor = sample_wsh_sortedmulti_cbor();
+        let arena: TerminalContext<8> = TerminalContext::new();
+        let decoded = decode_output_descriptor("output-descriptor", &cbor, &arena).unwrap();
+        assert!(matches!(decoded, Terminal::WitnessScriptHash(_)));
+    }
+
+    #[test]
+    fn test_decode_output_descriptor_rejects_other_types() {
+        let cbor = sample_wsh_sortedmulti_cbor();
+        let arena: TerminalContext<8> = TerminalContext::new();
+        match decode_output_descriptor("bytes", &cbor, &arena) {
+            Err(Error::UnsupportedResource) => {}
+            other => panic!("expected UnsupportedResource, got {other:?}"),
+        };
+    }
 
     #[test]
     fn test_byte_string_bytes() {

--- a/urtypes/src/value.rs
+++ b/urtypes/src/value.rs
@@ -67,13 +67,18 @@ impl<'a> Value<'a> {
         Ok(value)
     }
 
-    /// Whether `ur_type` is a known output-descriptor UR type.
+    /// Whether `ur_type` is the legacy `crypto-output` UR type (BCR-2020-010).
     ///
-    /// Accepts the historical `crypto-output` spelling (BCR-2020-010, still
-    /// emitted by e.g. Sparrow) as well as the newer `output-descriptor` and
-    /// short `output` aliases.
+    /// This is the flavor still emitted by e.g. Sparrow: a recursive CBOR
+    /// tree rooted at one of the script-type tags (400..=410) that decodes
+    /// into [`Terminal`].
+    ///
+    /// The newer BCR-2023-010 `output-descriptor` UR (CBOR tag 40308 map
+    /// wrapping a text descriptor) is NOT the same wire format and is not
+    /// accepted here; feeding its payload through [`decode_output_descriptor`]
+    /// would produce `InvalidCbor(invalid tag)`.
     pub fn is_output_descriptor(ur_type: &str) -> bool {
-        matches!(ur_type, "output" | "output-descriptor" | "crypto-output")
+        matches!(ur_type, "crypto-output")
     }
 
     /// Return the type of this value as a string.
@@ -96,7 +101,7 @@ impl<'a> Value<'a> {
     }
 }
 
-/// Decode a `crypto-output` / `output-descriptor` UR payload into a [`Terminal`].
+/// Decode a legacy `crypto-output` UR payload (BCR-2020-010) into a [`Terminal`].
 ///
 /// [`Terminal`] is a recursive data structure, so its sub-nodes are allocated
 /// into the caller-provided [`TerminalContext`] arena. `N` must be large
@@ -104,8 +109,9 @@ impl<'a> Value<'a> {
 /// `wsh(sortedmulti(...))` needs at least 2 slots).
 ///
 /// Dispatches on the UR type string so callers can route from a generic
-/// "got a UR" entry point without re-implementing the aliases. See
-/// [`Value::is_output_descriptor`] for the accepted spellings.
+/// "got a UR" entry point. Only `crypto-output` is accepted; the newer
+/// BCR-2023-010 `output-descriptor` (tag 40308) uses a different CBOR shape
+/// and is not supported by this helper. See [`Value::is_output_descriptor`].
 pub fn decode_output_descriptor<'a, 'b, const N: usize>(
     ur_type: &str,
     payload: &'b [u8],
@@ -177,9 +183,14 @@ mod tests {
 
     #[test]
     fn test_is_output_descriptor() {
-        assert!(Value::is_output_descriptor("output"));
-        assert!(Value::is_output_descriptor("output-descriptor"));
         assert!(Value::is_output_descriptor("crypto-output"));
+        // `output-descriptor` is a distinct BCR-2023-010 UR (tag 40308 map,
+        // not the tag-400..410 tree) and must NOT be accepted by this helper
+        // — the reviewer on PR #54 reproduced `InvalidCbor(invalid tag)`
+        // when a spec-compliant `output-descriptor` payload was routed here.
+        assert!(!Value::is_output_descriptor("output-descriptor"));
+        // Bare `output` is not a registered UR type at all.
+        assert!(!Value::is_output_descriptor("output"));
         assert!(!Value::is_output_descriptor("hdkey"));
         assert!(!Value::is_output_descriptor("crypto-hdkey"));
         assert!(!Value::is_output_descriptor(""));
@@ -229,11 +240,17 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_output_descriptor_new_alias() {
+    fn test_decode_output_descriptor_rejects_output_descriptor_alias() {
+        // BCR-2023-010 `output-descriptor` uses a different CBOR shape (tag
+        // 40308 map), so this helper — which only understands the legacy
+        // BCR-2020-010 tag-400..410 tree — must reject it at the type-string
+        // layer rather than handing the bytes to the wrong decoder.
         let cbor = sample_wsh_sortedmulti_cbor();
         let arena: TerminalContext<8> = TerminalContext::new();
-        let decoded = decode_output_descriptor("output-descriptor", &cbor, &arena).unwrap();
-        assert!(matches!(decoded, Terminal::WitnessScriptHash(_)));
+        match decode_output_descriptor("output-descriptor", &cbor, &arena) {
+            Err(Error::UnsupportedResource) => {}
+            other => panic!("expected UnsupportedResource, got {other:?}"),
+        };
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`foundation-urtypes` already ships a full `Terminal` CBOR decoder for BCR-2020-010 output descriptors (`registry/output_descriptor.rs`, tags 400–410 including `SortedMultisig`), but `Value::from_ur` doesn't route `crypto-output` payloads to it — so callers trying to import a Sparrow-style multisig UR hit `UnsupportedResource` and no path exists to wire it up without touching this crate.

`Value::from_ur` can't hold a `Terminal` directly because `Terminal<'a, 'b>` is a recursive, two-lifetime, arena-allocated tree and doesn't fit the single-lifetime `Value<'a>` enum. This PR adds a dedicated free function:

- `value::decode_output_descriptor(ur_type, payload, arena) -> Result<Terminal, Error>` — takes a caller-provided `TerminalContext` arena and dispatches on the UR type string.
- `Value::is_output_descriptor(ur_type) -> bool` — so downstream callers can route on type without re-implementing the acceptance check.

**Scope:** accepts only the legacy BCR-2020-010 `crypto-output` UR type (still emitted by e.g. Sparrow). The newer BCR-2023-010 `output-descriptor` UR (CBOR tag 40308 map wrapping a text descriptor) is a different wire format — feeding its payload to `decode_output_descriptor` produces `InvalidCbor(invalid tag)` — so it's rejected at the type-string layer with `UnsupportedResource`. Supporting it is out of scope for this PR and would need a separate v3 decoder.

## Review round 2

Narrowed the alias set per reviewer feedback:

- Removed `"output-descriptor"` alias — the BCR-2023-010 UR with that name is tag-40308 map, not the tag-400..410 tree this helper decodes. Routing it here produced `InvalidCbor(invalid tag)` on a spec-compliant payload.
- Removed bare `"output"` alias — not a registered UR type.
- Updated the helper's rustdoc to call out the distinction.
- Added tests that assert `output-descriptor` and other foreign type strings now surface `UnsupportedResource` at the dispatch layer rather than reaching the decoder.

## Context

This is PR 1 of 3 for SFT-6915, which adds Sparrow-style `crypto-output` multisig import on Prime:

1. **This PR** — foundation-rs/foundation-urtypes: expose the decode helper
2. Foundation-Devices/ngwallet#115 — `MultiSigDetails::from_crypto_output(&Terminal)` consuming this helper
3. Foundation-Devices/KeyOS-dev#1679 — wire the `crypto-output` UR path through `create_account.rs`

Linear: https://linear.app/foundation-devices/issue/SFT-6915

## Test plan

- [x] `cargo test -p foundation-urtypes` — all 5 value tests pass (including the new `output-descriptor` rejection test)
- [x] `cargo clippy -p foundation-urtypes` — no new warnings introduced
- [ ] Draft — holding for review; will be taken out of draft once the ngwallet PR is ready to chain on top

## Out of scope

- BCR-2023-010 `output-descriptor` (tag 40308) — needs a separate decoder against the text-descriptor-wrapped map format
- Taproot (`crypto-output` with tag 409) — Prime doesn't do taproot multisig yet
- `crypto-account` UR type — separate issue
- Actually consuming the helper — lives in the ngwallet PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)