### PR TITLE
SFT-7483: Preserve master private HD key bytes during UR decoding

### DIFF
--- a/urtypes/src/registry/hdkey.rs
+++ b/urtypes/src/registry/hdkey.rs
@@ -193,7 +193,10 @@ impl<'b, C> Decode<'b, C> for MasterKey {
                     let mut data = [0; 32];
 
                     let bytes: [u8; 33] = DecodeBytes::decode_bytes(d, ctx)?;
-                    data.copy_from_slice(&bytes[..32]);
+                    if bytes[0] != 0 {
+                        return Err(Error::message("master private key-data prefix is not zero"));
+                    }
+                    data.copy_from_slice(&bytes[1..]);
                     key_data = Some(data)
                 }
                 4 => chain_code = Some(DecodeBytes::decode_bytes(d, ctx)?),

--- a/urtypes/tests/hdkey.rs
+++ b/urtypes/tests/hdkey.rs
@@ -3,7 +3,11 @@
 
 use faster_hex::hex_string;
 use foundation_test_vectors::{HDKeyVector, URVector, UR};
-use foundation_urtypes::registry::{HDKeyRef, KeypathRef};
+use foundation_urtypes::{
+    registry::{HDKeyRef, KeypathRef, MasterKey},
+    value::{Error, Value},
+};
+use minicbor::Encoder;
 
 #[test]
 fn test_roundtrip_ref() {
@@ -30,5 +34,50 @@ fn test_roundtrip_ref() {
         println!("our cbor: {}", hex_string(&cbor));
         println!("test vector cbor: {}", hex_string(&vector.as_cbor));
         assert_eq!(cbor, vector.as_cbor);
+    }
+}
+
+#[test]
+fn master_private_key_roundtrips_through_value() {
+    let hdkey = HDKeyRef::MasterKey(MasterKey {
+        key_data: core::array::from_fn(|i| (i + 1) as u8),
+        chain_code: core::array::from_fn(|i| (0x80 + i) as u8),
+    });
+    let cbor = minicbor::to_vec(&hdkey).unwrap();
+
+    for ur_type in ["hdkey", "crypto-hdkey"] {
+        let decoded = Value::from_ur(ur_type, &cbor).unwrap();
+        assert_eq!(decoded, Value::HDKey(hdkey.clone()));
+    }
+}
+
+#[test]
+fn master_private_key_rejects_invalid_prefix_and_length() {
+    fn encode_master_key(key_data: &[u8]) -> Vec<u8> {
+        let mut cbor = Vec::new();
+        let mut encoder = Encoder::new(&mut cbor);
+        encoder.map(3).unwrap();
+        encoder.u8(1).unwrap();
+        encoder.bool(true).unwrap();
+        encoder.u8(3).unwrap();
+        encoder.bytes(key_data).unwrap();
+        encoder.u8(4).unwrap();
+        encoder.bytes(&[0x42; 32]).unwrap();
+        cbor
+    }
+
+    let mut invalid_prefix = [0x11; 33];
+    invalid_prefix[0] = 1;
+    let invalid_values = [
+        encode_master_key(&invalid_prefix),
+        encode_master_key(&[0; 32]),
+        encode_master_key(&[0; 34]),
+    ];
+
+    for cbor in invalid_values {
+        assert!(matches!(
+            Value::from_ur("crypto-hdkey", &cbor),
+            Err(Error::InvalidCbor(_))
+        ));
     }
 }


### PR DESCRIPTION
﻿## Summary

Fix master-private `hdkey` decoding so it validates the required zero prefix and copies all 32 secret-key bytes from the 33-byte BIP32 key-data field.

The previous decoder copied bytes `0..32`, retaining the prefix and dropping the final secret-key byte while returning success.

## Changes

- require the master private key-data prefix to be zero
- decode the secret from bytes `1..33`
- verify exact round trips through both `hdkey` and `crypto-hdkey` generic `Value` routes
- reject nonzero prefixes and key-data fields that are not exactly 33 bytes



