### PR TITLE
SFT-7491: keep authorization credentials out of the log

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -212,6 +212,20 @@
             }
           );
 
+          # --- Cargo test (stratum-v1 with the `log` backend) ---
+          #
+          # The all-features checks have to exclude stratum-v1, because several
+          # of its features are mutually exclusive. That leaves the credential
+          # redaction regression test — which needs a logging backend to have
+          # any output to assert over — unrun, so select it explicitly.
+          cargo-test-stratum-v1-log = craneLib.cargoTest (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              cargoTestExtraArgs = "-p stratum-v1 --features log";
+            }
+          );
+
           # --- cbindgen header verification ---
           cbindgen-verify =
             let

--- a/stratum-v1/src/client/mod.rs
+++ b/stratum-v1/src/client/mod.rs
@@ -3,6 +3,7 @@
 
 mod job;
 mod notification;
+mod redact;
 mod request;
 mod response;
 
@@ -10,6 +11,7 @@ use crate::{Error, Result};
 pub use job::Job;
 use job::JobCreator;
 use notification::Notification;
+use redact::Sensitivity;
 use request::ReqKind;
 pub use request::{Extensions, Info, Share, VersionRolling};
 use response::Subscription;
@@ -117,25 +119,29 @@ impl<C: Read + ReadReady + Write, const RX_BUF_SIZE: usize, const TX_BUF_SIZE: u
             .position(|&c| c == b'\n')
         {
             stop += start;
-            trace!("Buffer start: {:?}", &self.rx_buf[..start]);
-            trace!("Current : {:?}", &self.rx_buf[start..stop]);
-            trace!("Buffer end: {:?}", &self.rx_buf[stop..]);
             let line = &self.rx_buf[start..stop];
             trace!("Start: {}, Stop: {}", start, stop);
             debug!(
                 "Received Message [{}..{}], free pos: {}",
                 start, stop, self.rx_free_pos
             );
-            debug!(
-                "<< {}",
-                if let Ok(l) = core::str::from_utf8(line) {
-                    l
-                } else {
-                    "Invalid UTF-8"
-                }
-            );
+            // Classify before logging. Pools echo the submitted user back in
+            // the error detail of an authorization or share response, so a
+            // reply matched to one of those requests is as revealing as the
+            // request itself. Anything we cannot match stays loggable: it
+            // carries no credential of ours, and suppressing it would leave
+            // malformed frames undiagnosable.
+            let parsed_id = response::parse_id(line);
+            let inbound = match &parsed_id {
+                Ok(Some(id)) => match self.reqs.get(id) {
+                    Some(ReqKind::Authorize) | Some(ReqKind::Submit) => Sensitivity::Secret,
+                    _ => Sensitivity::Public,
+                },
+                _ => Sensitivity::Public,
+            };
+            debug!("<< {}", inbound.loggable(line));
             debug!("unresponded reqs: {:?}", self.reqs);
-            if let Some(id) = response::parse_id(line)? {
+            if let Some(id) = parsed_id? {
                 // it's a Response
                 match self.reqs.get(&id) {
                     Some(ReqKind::Configure) => {
@@ -251,12 +257,11 @@ impl<C: Read + ReadReady + Write, const RX_BUF_SIZE: usize, const TX_BUF_SIZE: u
                 .read(self.rx_buf[self.rx_free_pos..].as_mut())
                 .await
                 .map_err(|_| Error::Network)?;
+            // Only the size. A freshly read chunk spans an arbitrary number of
+            // frames, so there is no way to tell here whether one of them is a
+            // reply that echoes our credentials back; each frame is logged
+            // individually, and classified, once it has been framed above.
             debug!("read {} bytes @{}", n, self.rx_free_pos);
-            trace!(
-                "<< chunk: {:?}",
-                core::str::from_utf8(&self.rx_buf[self.rx_free_pos..self.rx_free_pos + n])
-            );
-            // trace!("{:?}", &self.rx_buf[self.rx_free_pos..self.rx_free_pos + n]);
             self.rx_free_pos += n;
         }
         Ok(msg)
@@ -276,17 +281,16 @@ impl<C: Read + ReadReady + Write, const RX_BUF_SIZE: usize, const TX_BUF_SIZE: u
         Ok(())
     }
 
-    async fn send(&mut self, len: usize) -> Result<()> {
+    /// Terminate and write the serialized request sitting in the transmit
+    /// buffer.
+    ///
+    /// `sensitivity` decides what reaches the log. It is a required argument
+    /// rather than something inferred here so that a new secret-bearing
+    /// request cannot be added without the author choosing a classification;
+    /// see [`Sensitivity`].
+    async fn send(&mut self, len: usize, sensitivity: Sensitivity) -> Result<()> {
         self.tx_buf[len] = 0x0a;
-        debug!(
-            ">> {}",
-            if let Ok(l) = core::str::from_utf8(&self.tx_buf[..len + 1]) {
-                l
-            } else {
-                "Invalid UTF-8"
-            }
-        );
-        // trace!("{:?}", &self.tx_buf[..len + 1]);
+        debug!(">> {}", sensitivity.loggable(&self.tx_buf[..len + 1]));
         self.network_conn
             .write_all(&self.tx_buf[..len + 1])
             .await
@@ -309,7 +313,7 @@ impl<C: Read + ReadReady + Write, const RX_BUF_SIZE: usize, const TX_BUF_SIZE: u
         self.prepare_req(ReqKind::Configure)?;
         let n = request::configure(self.req_id, exts, self.tx_buf.as_mut_slice())?;
         debug!("Send Configure: {} bytes, id = {}", n, self.req_id);
-        self.send(n).await
+        self.send(n, Sensitivity::Public).await
     }
 
     /// # Suggest Difficulty to Server
@@ -338,7 +342,7 @@ impl<C: Read + ReadReady + Write, const RX_BUF_SIZE: usize, const TX_BUF_SIZE: u
         let id = None;
         let n = request::suggest_difficulty(id, difficulty, self.tx_buf.as_mut_slice())?;
         debug!("Send Suggest Difficulty: {} bytes, id = {}", n, self.req_id);
-        self.send(n).await
+        self.send(n, Sensitivity::Public).await
     }
 
     /// # Connect Client
@@ -360,7 +364,7 @@ impl<C: Read + ReadReady + Write, const RX_BUF_SIZE: usize, const TX_BUF_SIZE: u
         self.prepare_req(ReqKind::Connect)?;
         let n = request::connect(self.req_id, identifier, self.tx_buf.as_mut_slice())?;
         debug!("Send Connect: {} bytes, id = {}", n, self.req_id);
-        self.send(n).await
+        self.send(n, Sensitivity::Public).await
     }
 
     /// # Authorize Client
@@ -386,7 +390,7 @@ impl<C: Read + ReadReady + Write, const RX_BUF_SIZE: usize, const TX_BUF_SIZE: u
         self.user = user.clone();
         let n = request::authorize(self.req_id, user, pass, self.tx_buf.as_mut_slice())?;
         debug!("Send Authorize: {} bytes, id = {}", n, self.req_id);
-        self.send(n).await
+        self.send(n, Sensitivity::Secret).await
     }
 
     /// # Submit a Share
@@ -418,6 +422,6 @@ impl<C: Read + ReadReady + Write, const RX_BUF_SIZE: usize, const TX_BUF_SIZE: u
             self.tx_buf.as_mut_slice(),
         )?;
         debug!("Send Submit: {} bytes, id = {}", n, self.req_id);
-        self.send(n).await
+        self.send(n, Sensitivity::Secret).await
     }
 }

--- a/stratum-v1/src/client/redact.rs
+++ b/stratum-v1/src/client/redact.rs
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: © 2026 Foundation Devices, Inc. <hello@foundation.xyz>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Log sensitivity of Stratum frames.
+//!
+//! `mining.authorize` carries the pool user and password, and `mining.submit`
+//! repeats the user on every share. Writing those frames to the log verbatim
+//! puts credentials into ordinary diagnostic output (CWE-532).
+//!
+//! Every frame the client logs is therefore routed through
+//! [`Sensitivity::loggable`], and it is that function's return value — never a
+//! buffer — that reaches a logging macro. Because the decision is made before
+//! the macro is invoked, it holds identically for both backends
+//! [`fmt`](crate::fmt) maps onto (`log` and `defmt-03`) and at every level:
+//! neither backend can observe a value this module withheld.
+
+/// Written in place of a frame that carries credentials.
+pub(crate) const REDACTED: &str = "<redacted: carries credentials>";
+
+/// Written in place of a frame that is not valid UTF-8.
+pub(crate) const INVALID_UTF8: &str = "Invalid UTF-8";
+
+/// Whether a frame may be written to the log verbatim.
+///
+/// The classification is about *credentials*, not about trust: a
+/// [`Public`](Sensitivity::Public) frame may still hold attacker-controlled
+/// bytes, it just cannot hold the pool user or password.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Sensitivity {
+    /// Safe to log in full.
+    ///
+    /// Outgoing, this covers `mining.configure`, `mining.subscribe` and
+    /// `mining.suggest_difficulty`: their parameters are the extension list,
+    /// the optional device identifier and a difficulty number — connection
+    /// metadata the caller chose to publish to the pool, none of it an
+    /// authorization parameter.
+    ///
+    /// Incoming, this covers notifications and every response that is not
+    /// matched to a pending `mining.authorize` or `mining.submit`.
+    Public,
+
+    /// Carries the pool user, the pool password, or both.
+    ///
+    /// Outgoing, this covers `mining.authorize` (user and password) and
+    /// `mining.submit` (the user is repeated in every share).
+    ///
+    /// Incoming, this covers responses matched to one of those two requests:
+    /// pools echo the submitted user back in error details, so the reply is as
+    /// revealing as the request.
+    Secret,
+}
+
+impl Sensitivity {
+    /// The text to hand to a logging macro for `frame`.
+    pub(crate) fn loggable<'a>(&self, frame: &'a [u8]) -> &'a str {
+        match self {
+            Sensitivity::Secret => REDACTED,
+            Sensitivity::Public => core::str::from_utf8(frame).unwrap_or(INVALID_UTF8),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The guarantee the whole module rests on: for a secret frame the return
+    /// value is a fixed string that borrows nothing from the frame, so no
+    /// backend and no level can reach the bytes.
+    #[test]
+    fn secret_frames_never_yield_their_contents() {
+        let authorize = br#"{"id":1,"method":"mining.authorize","params":["worker.001","s3cr3t"]}"#;
+        assert_eq!(Sensitivity::Secret.loggable(authorize), REDACTED);
+
+        let submit = br#"{"id":2,"method":"mining.submit","params":["worker.001","bf"]}"#;
+        assert_eq!(Sensitivity::Secret.loggable(submit), REDACTED);
+
+        // Including when the frame is empty or not valid UTF-8.
+        assert_eq!(Sensitivity::Secret.loggable(b""), REDACTED);
+        assert_eq!(Sensitivity::Secret.loggable(&[0xff, 0xfe]), REDACTED);
+    }
+
+    #[test]
+    fn public_frames_are_logged_verbatim() {
+        let subscribe = br#"{"id":1,"method":"mining.subscribe","params":[]}"#;
+        assert_eq!(
+            Sensitivity::Public.loggable(subscribe),
+            r#"{"id":1,"method":"mining.subscribe","params":[]}"#
+        );
+
+        assert_eq!(Sensitivity::Public.loggable(&[0xff, 0xfe]), INVALID_UTF8);
+    }
+}

--- a/stratum-v1/src/error.rs
+++ b/stratum-v1/src/error.rs
@@ -47,6 +47,15 @@ pub enum Error {
     NoWork,
 
     /// Pool reported an error
+    ///
+    /// # Logging
+    ///
+    /// `message` and `detail` are free text chosen by the pool, and pools do
+    /// echo the submitted user back in them — Public-Pool answers a failed
+    /// authorization with `[20, "Authorization validation error", ", <user>"]`.
+    /// The client never writes them to its own log for that reason; a caller
+    /// that logs this variant should treat both fields as it would the
+    /// credentials themselves. `code` is a number and always safe to log.
     Pool {
         code: isize,
         message: tstring!(32),

--- a/stratum-v1/src/lib.rs
+++ b/stratum-v1/src/lib.rs
@@ -4,6 +4,34 @@
 //! Stratum v1 client.
 //!
 //! This library provides client side functions to create requests and parse responses for Stratum v1 protocol.
+//!
+//! # Logging and credentials
+//!
+//! `mining.authorize` carries the pool user and password, and `mining.submit`
+//! repeats the user on every share. Neither frame is ever written to the log,
+//! under either backend and at any level; they are logged as their method,
+//! request id and byte count, with the serialized body replaced by a
+//! placeholder. The same applies to the pool's replies to those two requests,
+//! because pools echo the submitted user back in error details.
+//!
+//! What *is* logged, and is therefore documented as carrying no authorization
+//! parameter:
+//!
+//! - `mining.configure`, `mining.subscribe` and `mining.suggest_difficulty`, in
+//!   full. Their parameters are the extension list, the optional device
+//!   identifier and a difficulty number — connection metadata the caller has
+//!   chosen to publish to the pool.
+//! - Notifications and any response not matched to a pending authorization or
+//!   share, in full.
+//! - For every frame: byte counts, buffer offsets, request ids, the request
+//!   method, and the connection state transitions.
+//!
+//! Raw receive-buffer contents are not logged at all: a buffer spans an
+//! arbitrary number of frames, so at that point there is no way to tell whether
+//! one of them echoes a credential.
+//!
+//! [`Error::Pool`] is the one credential-adjacent value the library hands back
+//! rather than logging; see its documentation before logging it yourself.
 
 #![no_std]
 #![macro_use]

--- a/stratum-v1/tests/credential_redaction.rs
+++ b/stratum-v1/tests/credential_redaction.rs
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: © 2026 Foundation Devices, Inc. <hello@foundation.xyz>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Authorization credentials must not reach the log.
+//!
+//! Drives a full handshake against a mock pool with canary credentials and a
+//! capturing logger installed at the most verbose level, then asserts that
+//! neither canary appears anywhere in the captured output.
+//!
+//! This exercises the `log` backend. The `defmt-03` backend cannot be captured
+//! in a host test — it needs its linker sections and an ELF to decode against —
+//! but it does not need to be: `fmt` maps `debug!`/`trace!` onto both backends
+//! with the *same arguments*, and the redaction happens before the macro is
+//! invoked. Whatever a backend receives, it receives from
+//! `Sensitivity::loggable`, whose behaviour is pinned by the unit tests in
+//! `client::redact`.
+
+#![cfg(feature = "log")]
+
+use std::sync::{Mutex, OnceLock};
+
+use embedded_io_async::{ErrorType, Read, ReadReady, Write};
+use stratum_v1::{Client, Extensions, Info, Share, VersionRolling};
+
+/// Strings that must never be logged. Distinctive enough that a substring
+/// search cannot match them by accident, and split into a prefix and a worker
+/// suffix so a partial leak is caught too.
+const CANARY_TAG: &str = "CANARY7491";
+const CANARY_WORKER: &str = "worker001";
+const CANARY_PASS: &str = "CANARY7491PASSWORD";
+
+const RX: usize = 1024;
+const TX: usize = 1024;
+
+// ---------------------------------------------------------------- capture ---
+
+static CAPTURED: OnceLock<Mutex<String>> = OnceLock::new();
+
+fn captured() -> &'static Mutex<String> {
+    CAPTURED.get_or_init(|| Mutex::new(String::new()))
+}
+
+struct CapturingLogger;
+
+impl log::Log for CapturingLogger {
+    fn enabled(&self, _: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record) {
+        use std::fmt::Write as _;
+        let mut buf = captured().lock().unwrap();
+        let _ = writeln!(buf, "[{}] {}", record.level(), record.args());
+    }
+
+    fn flush(&self) {}
+}
+
+// -------------------------------------------------------------- mock pool ---
+
+struct MockPool {
+    rx: Vec<u8>,
+    rx_pos: usize,
+    tx: Vec<u8>,
+}
+
+impl ErrorType for MockPool {
+    type Error = embedded_io_async::ErrorKind;
+}
+
+impl Read for MockPool {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        let n = (self.rx.len() - self.rx_pos).min(buf.len());
+        buf[..n].copy_from_slice(&self.rx[self.rx_pos..self.rx_pos + n]);
+        self.rx_pos += n;
+        Ok(n)
+    }
+}
+
+impl ReadReady for MockPool {
+    fn read_ready(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.rx_pos < self.rx.len())
+    }
+}
+
+impl Write for MockPool {
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.tx.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+}
+
+async fn poll_until_message(client: &mut Client<MockPool, RX, TX>) {
+    for _ in 0..8 {
+        if client.poll_message().await.unwrap().is_some() {
+            return;
+        }
+    }
+    panic!("the mock pool produced no message");
+}
+
+// ------------------------------------------------------------------- test ---
+
+/// One test, not several: `log` allows a single logger per process, so the
+/// transcript is shared and parallel tests would race on it.
+#[tokio::test]
+async fn credentials_never_reach_the_log() {
+    log::set_boxed_logger(Box::new(CapturingLogger)).expect("no other logger is installed");
+    log::set_max_level(log::LevelFilter::Trace);
+
+    let user = format!("{CANARY_TAG}USER.{CANARY_WORKER}");
+
+    let mut responses = Vec::new();
+    for line in [
+        r#"{"error":null,"id":1,"result":{"version-rolling":true,"version-rolling.mask":"1fffe000"}}"#.to_string(),
+        r#"{"id":2,"error":null,"result":[[["mining.notify","1"]],"e26e1928",4]}"#.to_string(),
+        r#"{"id":3,"result":true,"error":null}"#.to_string(),
+        // Public-Pool echoes part of the submitted user in the error detail,
+        // so the reply leaks what the request did.
+        format!(r#"{{"id":4,"result":null,"error":[20,"Stale share",", {user}"]}}"#),
+    ] {
+        responses.extend_from_slice(line.as_bytes());
+        responses.push(b'\n');
+    }
+
+    let mut client: Client<_, RX, TX> = Client::new(MockPool {
+        rx: responses,
+        rx_pos: 0,
+        tx: Vec::new(),
+    });
+
+    client
+        .send_configure(Extensions {
+            version_rolling: Some(VersionRolling {
+                mask: Some(0x1fff_e000),
+                min_bit_count: Some(2),
+            }),
+            minimum_difficulty: None,
+            subscribe_extranonce: None,
+            info: Some(Info {
+                connection_url: None,
+                hw_version: None,
+                sw_version: None,
+                hw_id: None,
+            }),
+        })
+        .await
+        .unwrap();
+    poll_until_message(&mut client).await;
+
+    client.send_connect(None).await.unwrap();
+    poll_until_message(&mut client).await;
+
+    client
+        .send_authorize(
+            user.as_str().try_into().unwrap(),
+            CANARY_PASS.try_into().unwrap(),
+        )
+        .await
+        .unwrap();
+    poll_until_message(&mut client).await;
+
+    // `send_submit` reuses the stored user, so the share frame carries it too.
+    #[cfg(feature = "alloc")]
+    let extranonce2 = alloc_vec();
+    #[cfg(not(feature = "alloc"))]
+    let extranonce2 = heapless::Vec::from_slice(&[0, 0, 0, 1]).unwrap();
+
+    client
+        .send_submit(Share {
+            job_id: "bf".try_into().unwrap(),
+            extranonce2,
+            ntime: 0x504e_86ed,
+            nonce: 0xb295_7c02,
+            version_bits: None,
+        })
+        .await
+        .unwrap();
+    poll_until_message(&mut client).await;
+
+    let log = captured().lock().unwrap().clone();
+
+    assert!(
+        !log.contains(CANARY_PASS),
+        "the pool password was logged:\n{log}"
+    );
+    assert!(!log.contains(&user), "the pool user was logged:\n{log}");
+    // Catch a partial leak too, in case the user is ever split across records.
+    assert!(
+        !log.contains(CANARY_TAG),
+        "part of a credential was logged:\n{log}"
+    );
+    assert!(
+        !log.contains(CANARY_WORKER),
+        "the worker name was logged:\n{log}"
+    );
+
+    // The transcript is only meaningful if logging actually happened, and an
+    // authorization failure has to stay diagnosable: method, id and byte count
+    // all survive redaction.
+    assert!(log.contains("Send Authorize"), "nothing was logged:\n{log}");
+    assert!(log.contains("Send Submit"), "nothing was logged:\n{log}");
+    assert!(
+        log.contains("<redacted"),
+        "secret frames should be logged as redacted, not dropped:\n{log}"
+    );
+    // Frames with no credential in them stay legible.
+    assert!(
+        log.contains("mining.subscribe"),
+        "public frames should still be logged in full:\n{log}"
+    );
+}
+
+#[cfg(feature = "alloc")]
+fn alloc_vec() -> Vec<u8> {
+    vec![0, 0, 0, 1]
+}


### PR DESCRIPTION
send() wrote the whole serialized transmit buffer to the log at debug level, so mining.authorize put the pool user and password into ordinary diagnostic output (CWE-532). mining.submit repeats the user in every share, and pools echo it back at us: Public-Pool answers a failed authorization with [20, "...", ", <user>"].

Every frame the client logs now goes through Sensitivity::loggable, and it is that return value, never a buffer, that reaches a logging macro. The decision is made before the macro is invoked, so it holds for both backends fmt maps onto and at every level. send() takes the classification as a required argument rather than inferring it, so a new secret-bearing request cannot be added without someone choosing one.

Classified secret: mining.authorize and mining.submit, plus any response matched to a pending one of those. Everything else is logged in full and documented in the crate docs as carrying no authorization parameter.

Raw receive-buffer dumps are gone. A buffer, and a freshly read chunk, span an arbitrary number of frames, so at that point there is no way to tell whether one of them echoes a credential; the per-frame log covers the useful case and can be classified. The commented-out transmit-buffer dump is removed too rather than left as an invitation.

Error::Pool is the one credential-adjacent value handed back rather than logged, since its message and detail are pool-chosen text that can echo the user. Documented on the variant.

The regression test drives a full handshake with canary credentials and a capturing logger at trace level, and asserts neither canary nor any fragment appears. It caught the read-path chunk dump that reading the send path alone would have missed. defmt cannot be captured in a host test, so it is covered by construction plus unit tests pinning loggable. Adds a flake check so the log-gated test actually runs; the all-features checks have to exclude this crate.